### PR TITLE
Fixed Launchpad.update

### DIFF
--- a/src/launchpad/core.clj
+++ b/src/launchpad/core.clj
@@ -68,7 +68,7 @@
     ;; enough not to warrant double-buffering here, so I haven't
     ;; implemented it. But if flickering becomes an issue, that's an
     ;; option.
-    (let [oldstate state
+    (let [oldstate (.state this)
                                         ; Any IState will do.
           newstate (.state newstate)]
       ;; grid


### PR DESCRIPTION
oldstate was not bound correctly, therefore (= old new) was always false. This
caused update to send excessive MIDI traffic to the Launchpad. This seems to
trigger a bug in the firmware of the Launchpad S, causing it to respond with
erratic note-on events.
